### PR TITLE
Build events page with date and filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
       },
       "scripts": {
           "dev": "vite",
-          "build": "vite build && cp admin.html build/admin.html && mkdir -p build/src/data && cp src/data/resources.json build/src/data/",
+      "build": "vite build && cp admin.html build/admin.html && mkdir -p build/src/data && cp src/data/resources.json build/src/data/ && cp src/data/events.json build/src/data/",
           "preview": "vite preview",
           "deploy": "vercel --prod",
           "deploy:preview": "vercel"

--- a/src/Events.tsx
+++ b/src/Events.tsx
@@ -1,0 +1,306 @@
+import { useEffect, useMemo, useState } from "react";
+import { Header } from "./components/Header";
+import { Footer } from "./components/Footer";
+import { EventCard, EventItem } from "./components/EventCard";
+
+const pageAnimation = `
+  @keyframes pageContentFadeIn {
+    0% { opacity: 0; transform: translateY(20px); }
+    100% { opacity: 1; transform: translateY(0); }
+  }
+`;
+
+type ViewMode = "month" | "organization";
+
+interface EventsResponse {
+  events: EventItem[];
+}
+
+function getMonthKey(dateStr: string): string {
+  const d = new Date(dateStr);
+  const y = d.getFullYear();
+  const m = d.getMonth();
+  return `${y}-${String(m + 1).padStart(2, "0")}`; // e.g., 2025-10
+}
+
+function monthLabelFromKey(key: string): string {
+  const [y, m] = key.split("-");
+  const d = new Date(Number(y), Number(m) - 1, 1);
+  return d.toLocaleString(undefined, { month: "short", year: "numeric" });
+}
+
+export default function Events() {
+  const [viewMode, setViewMode] = useState<ViewMode>("month");
+  const [events, setEvents] = useState<EventItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
+
+  const toggleSection = (sectionId: string) => {
+    setCollapsedSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(sectionId)) next.delete(sectionId);
+      else next.add(sectionId);
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    const loadEvents = async () => {
+      try {
+        setIsLoading(true);
+        // Try remote GitHub JSON first
+        const remoteUrl = `https://raw.githubusercontent.com/JaneAdora/ebrtq/main/src/data/events.json?v=${Date.now()}`;
+        let response = await fetch(remoteUrl);
+        if (!response.ok) {
+          // Fallback to local file (served in build via vercel.json rewrite)
+          response = await fetch(`/src/data/events.json?v=${Date.now()}`);
+        }
+        if (!response.ok) {
+          throw new Error("Failed to load events");
+        }
+        const data: EventsResponse = await response.json();
+        // Basic normalization and sorting by date asc
+        const normalized = (data.events || []).map((ev) => ({
+          ...ev,
+          organization: ev.organization || ev.provider,
+        }));
+        normalized.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+        setEvents(normalized);
+        setError(null);
+      } catch (e) {
+        console.error(e);
+        setError("Failed to load events. Please try again later.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadEvents();
+  }, []);
+
+  const byOrganization = useMemo(() => {
+    return events.reduce((acc, ev) => {
+      const org = ev.organization || "Other";
+      if (!acc[org]) acc[org] = [];
+      acc[org].push(ev);
+      return acc;
+    }, {} as Record<string, EventItem[]>);
+  }, [events]);
+
+  const byMonth = useMemo(() => {
+    const grouped = events.reduce((acc, ev) => {
+      const key = getMonthKey(ev.date);
+      if (!acc[key]) acc[key] = [];
+      acc[key].push(ev);
+      return acc;
+    }, {} as Record<string, EventItem[]>);
+    // sort events within month by date asc
+    Object.values(grouped).forEach((arr) => arr.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()));
+    return grouped;
+  }, [events]);
+
+  const sortedMonthKeys = useMemo(() => {
+    return Object.keys(byMonth).sort((a, b) => {
+      const [ya, ma] = a.split("-").map(Number);
+      const [yb, mb] = b.split("-").map(Number);
+      if (ya !== yb) return ya - yb;
+      return ma - mb;
+    });
+  }, [byMonth]);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4 py-8 bg-gradient-to-br from-pink-100 via-blue-50 to-purple-100">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-pink-500 mx-auto mb-4" />
+          <h2 className="text-xl font-semibold text-gray-700 mb-2">Loading Events...</h2>
+          <p className="text-gray-600">Please wait while we load the latest events.</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4 py-8 bg-gradient-to-br from-pink-100 via-blue-50 to-purple-100">
+        <div className="text-center max-w-md">
+          <div className="text-red-500 text-6xl mb-4">⚠️</div>
+          <h2 className="text-xl font-semibold text-gray-700 mb-2">Unable to Load Events</h2>
+          <p className="text-gray-600 mb-4">{error}</p>
+          <button 
+            onClick={() => window.location.reload()} 
+            className="bg-pink-500 hover:bg-pink-600 text-white px-6 py-2 rounded-lg font-medium transition-colors"
+          >
+            Try Again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="min-h-screen flex flex-col items-center px-4 py-8"
+      style={{
+        background: "linear-gradient(135deg, #1e1e2e 0%, #2a1f3d 25%, #1f2937 50%, #1e3a5f 75%, #1e1e2e 100%)",
+        backgroundSize: "400% 400%",
+        animation: "gradient 15s ease infinite",
+      }}
+    >
+      <style>{`
+        @keyframes gradient { 0% { background-position: 0% 50%; } 50% { background-position: 100% 50%; } 100% { background-position: 0% 50%; } }
+      `}</style>
+      <div className="w-full max-w-4xl">
+        <style>{pageAnimation}</style>
+        <Header />
+
+        {/* Toggle */}
+        <div
+          className="flex gap-4 mb-8 justify-center"
+          style={{ animation: "pageContentFadeIn 1.5s ease-out 1.2s both" }}
+        >
+          <button
+            onClick={() => setViewMode("month")}
+            className={`px-6 py-3 border-4 transition-all duration-300 ${
+              viewMode === "month" ? "scale-105" : "opacity-60 hover:opacity-100 hover:scale-110"
+            }`}
+            style={{
+              borderColor: viewMode === "month" ? "#00F5FF" : "rgba(0, 245, 255, 0.3)",
+              boxShadow:
+                viewMode === "month"
+                  ? "4px 4px 0 0 #00F5FF, 0 0 25px rgba(0, 245, 255, 0.6)"
+                  : "none",
+              fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', 'Courier New', monospace",
+              letterSpacing: "0.1em",
+              imageRendering: "pixelated",
+              backgroundColor: "rgba(42, 45, 58, 0.7)",
+              backdropFilter: "blur(10px)",
+              cursor: viewMode === "month" ? "default" : "pointer",
+            }}
+          >
+            BY MONTH
+          </button>
+
+          <button
+            onClick={() => setViewMode("organization")}
+            className={`px-6 py-3 border-4 transition-all duration-300 ${
+              viewMode === "organization" ? "scale-105" : "opacity-60 hover:opacity-100 hover:scale-110"
+            }`}
+            style={{
+              borderColor: viewMode === "organization" ? "#FF69B4" : "rgba(255, 105, 180, 0.3)",
+              boxShadow:
+                viewMode === "organization"
+                  ? "4px 4px 0 0 #FF69B4, 0 0 25px rgba(255, 105, 180, 0.6)"
+                  : "none",
+              fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', 'Courier New', monospace",
+              letterSpacing: "0.1em",
+              imageRendering: "pixelated",
+              backgroundColor: "rgba(42, 45, 58, 0.7)",
+              backdropFilter: "blur(10px)",
+              cursor: viewMode === "organization" ? "default" : "pointer",
+            }}
+          >
+            BY ORGANIZATION
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="space-y-8" style={{ animation: "pageContentFadeIn 1.5s ease-out 1.2s both" }}>
+          {viewMode === "organization" ? (
+            Object.entries(byOrganization).map(([org, orgEvents]) => {
+              const sectionId = `org-${org}`;
+              const isCollapsed = collapsedSections.has(sectionId);
+              return (
+                <div key={org}>
+                  <h2
+                    className="mb-4 pb-2 border-b-4 cursor-pointer transition-all duration-300 hover:opacity-80"
+                    onClick={() => toggleSection(sectionId)}
+                    style={{
+                      fontFamily: "'Orbitron', monospace",
+                      fontSize: "1.75rem",
+                      letterSpacing: "0.15em",
+                      borderColor: "#FF69B4",
+                      color: "#FFFFFF",
+                      textShadow: "0 0 20px rgba(255, 105, 180, 0.9)",
+                      cursor: "pointer",
+                    }}
+                  >
+                    <span
+                      style={{
+                        color: "#FF69B4",
+                        transform: isCollapsed ? "rotate(0deg)" : "rotate(90deg)",
+                        display: "inline-block",
+                        transition: "transform 0.3s ease",
+                        fontSize: "1.5em",
+                        marginRight: "0.5em",
+                      }}
+                    >
+                      ▸
+                    </span>
+                    {org}
+                  </h2>
+                  {!isCollapsed && (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-3">
+                      {orgEvents.map((ev) => (
+                        <EventCard key={ev.id} event={ev} />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          ) : (
+            sortedMonthKeys.map((key) => {
+              const sectionId = `month-${key}`;
+              const isCollapsed = collapsedSections.has(sectionId);
+              const monthEvents = byMonth[key] || [];
+              return (
+                <div key={key}>
+                  <h2
+                    className="mb-4 pb-2 border-b-4 cursor-pointer transition-all duration-300 hover:opacity-80"
+                    onClick={() => toggleSection(sectionId)}
+                    style={{
+                      fontFamily: "'Orbitron', monospace",
+                      fontSize: "1.75rem",
+                      letterSpacing: "0.15em",
+                      borderColor: "#00F5FF",
+                      color: "#FFFFFF",
+                      textShadow: "0 0 20px rgba(0, 245, 255, 0.8)",
+                      cursor: "pointer",
+                    }}
+                  >
+                    <span
+                      style={{
+                        color: "#00F5FF",
+                        transform: isCollapsed ? "rotate(0deg)" : "rotate(90deg)",
+                        display: "inline-block",
+                        transition: "transform 0.3s ease",
+                        fontSize: "1.5em",
+                        marginRight: "0.5em",
+                      }}
+                    >
+                      ▸
+                    </span>
+                    {monthLabelFromKey(key)}
+                  </h2>
+                  {!isCollapsed && (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-3">
+                      {monthEvents.map((ev) => (
+                        <EventCard key={ev.id} event={ev} />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <div style={{ animation: "pageContentFadeIn 1.5s ease-out 1.2s both" }}>
+          <Footer />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+
+export interface EventItem {
+  id: string;
+  title: string;
+  url: string;
+  organization?: string; // preferred field name
+  provider?: string; // fallback field name in case JSON uses provider
+  type?: string;
+  date: string; // ISO date string, e.g. 2025-10-03
+  timeFrom?: string; // HH:mm or H:mm
+  timeTo?: string; // HH:mm or H:mm
+  color?: "blue" | "pink" | "white" | "purple" | "magenta" | "cyan" | "green";
+}
+
+interface EventCardProps {
+  event: EventItem;
+}
+
+function formatTime12h(time?: string): string | null {
+  if (!time) return null;
+  // Accept formats like HH:mm or H:mm
+  const match = time.match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) return time; // return as-is if unknown format
+  const hours = parseInt(match[1], 10);
+  const minutes = match[2];
+  const period = hours >= 12 ? "PM" : "AM";
+  const hour12 = ((hours + 11) % 12) + 1; // 0->12, 13->1 etc
+  return `${hour12}:${minutes} ${period}`;
+}
+
+function getMonthAbbrev(dateStr: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleString(undefined, { month: "short" });
+}
+
+function getDayNumber(dateStr: string): string {
+  const d = new Date(dateStr);
+  return String(d.getDate());
+}
+
+export function EventCard({ event }: EventCardProps) {
+  const { title, url, date, timeFrom, timeTo } = event;
+
+  const color = event.color ?? "cyan";
+  const colors: Record<NonNullable<EventItem["color"]>, string> = {
+    blue: "#5BCEFA",
+    pink: "#F5A9B8",
+    white: "#FFFFFF",
+    purple: "#BB86FC",
+    magenta: "#FF006E",
+    cyan: "#00F5FF",
+    green: "#39FF14",
+  };
+
+  const glowRgba: Record<NonNullable<EventItem["color"]>, string> = {
+    blue: "91, 206, 250",
+    pink: "245, 169, 184",
+    white: "255, 255, 255",
+    purple: "187, 134, 252",
+    magenta: "255, 0, 110",
+    cyan: "0, 245, 255",
+    green: "57, 255, 20",
+  };
+
+  const month = getMonthAbbrev(date);
+  const day = getDayNumber(date);
+
+  const from12h = formatTime12h(timeFrom || undefined);
+  const to12h = formatTime12h(timeTo || undefined);
+  const timeLabel = from12h && to12h ? `${from12h} - ${to12h}` : from12h || to12h || "";
+
+  return (
+    <a
+      href={url}
+      className="relative block p-4 border-4 transition-all duration-200 hover:scale-105 min-h-[180px]"
+      style={{
+        borderColor: colors[color],
+        boxShadow: `4px 4px 0 0 ${colors[color]}, 0 0 20px rgba(${glowRgba[color]}, 0.35)`,
+        imageRendering: "pixelated",
+        backgroundColor: "rgba(42, 45, 58, 0.6)",
+        backdropFilter: "blur(10px)",
+      }}
+    >
+      {/* Date badge - top-left */}
+      <div
+        className="absolute top-3 left-3 flex flex-col items-center justify-center px-2 py-1 border-2"
+        style={{
+          borderColor: colors[color],
+          backgroundColor: "rgba(26, 29, 42, 0.85)",
+        }}
+      >
+        <div
+          style={{
+            fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+            fontSize: "1.75rem",
+            lineHeight: 1,
+            color: colors[color],
+          }}
+        >
+          {day}
+        </div>
+        <div
+          style={{
+            fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+            fontSize: "0.75rem",
+            letterSpacing: "0.08em",
+            color: colors[color],
+            opacity: 0.9,
+          }}
+        >
+          {month.toUpperCase()}
+        </div>
+      </div>
+
+      {/* Content area */}
+      <div className="pl-24 pr-2 flex flex-col h-full">
+        <h3
+          className="mb-2"
+          style={{
+            fontFamily: "'Orbitron', monospace",
+            fontSize: "1.25rem",
+            letterSpacing: "0.06em",
+            color: "#FFFFFF",
+            textShadow: "0 0 12px rgba(187, 134, 252, 0.6)",
+          }}
+        >
+          {title}
+        </h3>
+        {timeLabel && (
+          <div
+            className="text-sm mb-2"
+            style={{ fontFamily: "'JetBrains Mono', monospace", color: "#BB86FC" }}
+          >
+            {timeLabel}
+          </div>
+        )}
+        {/* Organization label if present */}
+        {(event.organization || event.provider) && (
+          <div
+            className="mt-auto text-xs opacity-80"
+            style={{ fontFamily: "'JetBrains Mono', monospace", color: "#5BCEFA" }}
+          >
+            {(event.organization || event.provider) as string}
+          </div>
+        )}
+      </div>
+    </a>
+  );
+}

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -1,0 +1,26 @@
+{
+  "events": [
+    {
+      "id": "event-1",
+      "title": "Community Gathering",
+      "url": "https://example.com/event-1",
+      "organization": "EBRTQ",
+      "type": "Meetup",
+      "date": "2025-10-15",
+      "timeFrom": "18:00",
+      "timeTo": "20:00",
+      "color": "pink"
+    },
+    {
+      "id": "event-2",
+      "title": "Workshop: Health Resources",
+      "url": "https://example.com/event-2",
+      "provider": "Health Org",
+      "type": "Workshop",
+      "date": "2025-11-03",
+      "timeFrom": "09:30",
+      "timeTo": "11:00",
+      "color": "cyan"
+    }
+  ]
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,11 @@
 
   import { createRoot } from "react-dom/client";
   import App from "./App.tsx";
+  import Events from "./Events.tsx";
   import "./index.css";
 
-  createRoot(document.getElementById("root")!).render(<App />);
+  const rootEl = document.getElementById("root")!;
+  const path = window.location.pathname;
+  const element = path.startsWith("/events") ? <Events /> : <App />;
+  createRoot(rootEl).render(element);
   

--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,10 @@
       "destination": "/src/data/resources.json"
     },
     {
+      "source": "/src/data/events.json",
+      "destination": "/src/data/events.json"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
Add a new `/events` page with event cards and filtering functionality.

This PR introduces a dedicated page for events, mirroring the structure of the existing resources page but with specific display requirements for event dates and times, a taller card layout, and toggleable grouping by month or organization.

---
<a href="https://cursor.com/background-agent?bcId=bc-eca67866-0fc3-4d04-8222-d37de911e350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eca67866-0fc3-4d04-8222-d37de911e350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

